### PR TITLE
Add overriden env for redis connect sinker

### DIFF
--- a/charts/kafka-connect-redis-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-redis-sink/templates/deployment.yaml
@@ -241,3 +241,11 @@ spec:
           value: {{ .Values.errorPolicy | quote }}
         - name: CONNECTOR_CONNECT_PROGRESS_ENABLED
           value: {{ .Values.progressEnabled | quote }}
+        
+        # override config
+        {{- if .Values.overrideEnv }}
+        {{- range $key, $value := .Values.overrideEnv }}
+        - name: {{ $key | quote }}
+          value: {{  $value | quote }}
+        {{- end }}
+        {{- end }}

--- a/charts/kafka-connect-redis-sink/values.yaml
+++ b/charts/kafka-connect-redis-sink/values.yaml
@@ -97,6 +97,9 @@ topics: "__REQUIRED__"
 # kcql connect.redis.kcql type: STRING importance: HIGH
 kcql: "__REQUIRED__"
 
+# Any env that needs to be overwritten
+overrideEnv: {}
+
 # password stored in the secret for Redis
 password: "__REQUIRED__"
 


### PR DESCRIPTION
This is to be merged after: https://github.com/VorTECHsa/kafka-helm-charts/pull/3